### PR TITLE
add .babelrc for fix npm run startWebsite error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+    "plugins": ["@babel/plugin-transform-runtime"]
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "notie": "^4.3.1"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.6.3",
+    "@babel/core": "^7.6.4",
+    "@babel/plugin-transform-runtime": "^7.6.2",
     "parcel": "^1.12.3"
   }
 }


### PR DESCRIPTION
The following errors will occur in the operation without addition: **`Uncaught ReferenceError: regeneratorRuntime is not defined`**