### PR TITLE
fix: get star count

### DIFF
--- a/src/components/StarChartViewer.vue
+++ b/src/components/StarChartViewer.vue
@@ -368,8 +368,7 @@ const handleShareToTwitterBtnClick = async () => {
     let starCount = 0;
 
     try {
-      const { data } = await api.getRepoStargazersCount(repo, store.token);
-      starCount = data.stargazers_count;
+      starCount = await api.getRepoStargazersCount(repo, store.token);
     } catch (error) {
       // do nth
     }


### PR DESCRIPTION
Fix the related api return data structure changed in last commit:
https://github.com/bytebase/star-history/pull/133/files#diff-c55d08b0e812373fac759c6c71d71f0085f0b2e0ee954ff74dfdf982ec3d760aR25