### PR TITLE
feat: use env file to save tokens instead of variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 dist-ssr
 *.local
+*.env

--- a/server/token.ts
+++ b/server/token.ts
@@ -3,14 +3,22 @@ import * as process from "process";
 import logger from "./logger";
 import api from "../common/api";
 
-// All secret files in render are available to load by absolute path at /etc/secrets/<filename>.
-const ENV_PATH_IN_RENDER = "/etc/secrets/token.env";
+// Token env file path in render.com: All secret files you create are available to read at the root of your repo.
+const ENV_PATH_IN_RENDER = "./token.env";
+// For local dev, you need to pass the ENVPATH value in env variables.
+// e.g. ENVPATH=PATH_TO_YOUR_FILE yarn dev
+// For production, we set a token.env file in render.com,
+// and copy of the file is store in bytebase/secret repo on GitHub.
+const envFilePath = process.env.ENVPATH || ENV_PATH_IN_RENDER;
 
 const savedTokens: string[] = [];
 let index = 0;
 
 export const initTokenFromEnv = async () => {
-  const envFilePath = process.env.ENVPATH || ENV_PATH_IN_RENDER;
+  if (!fs.existsSync(envFilePath)) {
+    logger.error("Token file not found with path ", envFilePath);
+    process.exit(-1);
+  }
   const envTokenString = fs.readFileSync(envFilePath).toString();
   if (!envTokenString) {
     logger.error("Token not found");

--- a/server/token.ts
+++ b/server/token.ts
@@ -1,3 +1,4 @@
+import * as fs from "fs";
 import * as process from "process";
 import logger from "./logger";
 import api from "../common/api";
@@ -6,7 +7,8 @@ const savedTokens: string[] = [];
 let index = 0;
 
 export const initTokenFromEnv = async () => {
-  const envTokenString = process.env.TOKEN;
+  const envFilePath = process.env.ENVPATH || "/etc/secrets/.env";
+  const envTokenString = fs.readFileSync(envFilePath).toString();
   if (!envTokenString) {
     logger.error("Token not found");
     process.exit(-1);

--- a/server/token.ts
+++ b/server/token.ts
@@ -8,7 +8,7 @@ const ENV_PATH_IN_RENDER = "./token.env";
 // For local dev, you need to pass the ENVPATH value in env variables.
 // e.g. ENVPATH=PATH_TO_YOUR_FILE yarn dev
 // For production, we set a token.env file in render.com,
-// and copy of the file is store in bytebase/secret repo on GitHub.
+// and the copy of the file is stored at https://github.com/bytebase/secret/tree/master/token/star-history.
 const envFilePath = process.env.ENVPATH || ENV_PATH_IN_RENDER;
 
 const savedTokens: string[] = [];

--- a/server/token.ts
+++ b/server/token.ts
@@ -14,7 +14,7 @@ export const initTokenFromEnv = async () => {
     process.exit(-1);
   }
 
-  const tokenList = envTokenString.split(",");
+  const tokenList = envTokenString.split(/\r?\n/);
   // Call GitHub API to check token usability
   for (const token of tokenList) {
     try {

--- a/server/token.ts
+++ b/server/token.ts
@@ -3,11 +3,14 @@ import * as process from "process";
 import logger from "./logger";
 import api from "../common/api";
 
+// All secret files in render are available to load by absolute path at /etc/secrets/<filename>.
+const ENV_PATH_IN_RENDER = "/etc/secrets/token.env";
+
 const savedTokens: string[] = [];
 let index = 0;
 
 export const initTokenFromEnv = async () => {
-  const envFilePath = process.env.ENVPATH || "/etc/secrets/.env";
+  const envFilePath = process.env.ENVPATH || ENV_PATH_IN_RENDER;
   const envTokenString = fs.readFileSync(envFilePath).toString();
   if (!envTokenString) {
     logger.error("Token not found");


### PR DESCRIPTION
We now use the environment variable to pass the secret tokens. But it's hard to manage if the amount of token is getting bigger and bigger. So I change to use an env file to save tokens instead of variables in this PR.