### PR TITLE
Fix #96, use unambiguous default date format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 dist-ssr
 *.local
 *.env
+.pnpm-debug.log

--- a/packages/xy-chart/index.ts
+++ b/packages/xy-chart/index.ts
@@ -74,7 +74,7 @@ export interface XYChartOptions {
 const getDefaultOptions = (): XYChartOptions => {
   return {
     xTickLabelType: "Date",
-    dateFormat: "MM/DD/YYYY",
+    dateFormat: "MMM DD, YYYY",
     xTickCount: 5,
     yTickCount: 5,
     showLine: true,


### PR DESCRIPTION
<img width="792" alt="Screen Shot 2022-03-26 at 07 31 24" src="https://user-images.githubusercontent.com/116473/160214509-962d820d-9b95-4d2f-b80d-90f36e4368ef.png">
