### PR TITLE
chore: some minor adjustments to the chart

### DIFF
--- a/packages/xy-chart/index.ts
+++ b/packages/xy-chart/index.ts
@@ -124,8 +124,13 @@ const XYChart = (
     .style("stroke-width", 3)
     .style("font-family", fontFamily)
     .style("background", options.backgroundColor)
-    .attr("width", clientWidth)
-    .attr("height", clientHeight) as D3Selection;
+    .attr("width", clientWidth <= 600 ? 600 : "100%")
+    .attr("height", clientHeight)
+    .attr(
+      "viewBox",
+      `0 0 ${clientWidth <= 600 ? 600 : clientWidth} ${clientHeight}`
+    )
+    .attr("preserveAspectRatio", "xMidYMid meet") as D3Selection;
   d3Selection.selectAll("*").remove();
 
   addFont(d3Selection);

--- a/packages/xy-chart/index.ts
+++ b/packages/xy-chart/index.ts
@@ -60,6 +60,7 @@ export interface XYChartConfig {
 type XTickLabelType = "Date" | "Number";
 
 export interface XYChartOptions {
+  envType: "browser" | "node";
   xTickLabelType: XTickLabelType;
   dateFormat?: string;
 
@@ -71,12 +72,12 @@ export interface XYChartOptions {
   fontFamily: string;
   backgroundColor: string;
   strokeColor: string;
-
   chartWidth?: number;
 }
 
 const getDefaultOptions = (): XYChartOptions => {
   return {
+    envType: "node",
     xTickLabelType: "Date",
     dateFormat: "MMM DD, YYYY",
     xTickCount: 5,
@@ -124,13 +125,18 @@ const XYChart = (
     .style("stroke-width", 3)
     .style("font-family", fontFamily)
     .style("background", options.backgroundColor)
-    .attr("width", clientWidth <= 600 ? 600 : "100%")
+    .attr("width", clientWidth)
     .attr("height", clientHeight)
-    .attr(
-      "viewBox",
-      `0 0 ${clientWidth <= 600 ? 600 : clientWidth} ${clientHeight}`
-    )
     .attr("preserveAspectRatio", "xMidYMid meet") as D3Selection;
+  if (options.envType === "browser") {
+    // If in browser, be more responsive.
+    d3Selection
+      .attr("width", clientWidth <= 600 ? 600 : "100%")
+      .attr(
+        "viewBox",
+        `0 0 ${clientWidth <= 600 ? 600 : clientWidth} ${clientHeight}`
+      );
+  }
   d3Selection.selectAll("*").remove();
 
   addFont(d3Selection);

--- a/packages/xy-chart/utils/drawLabels.ts
+++ b/packages/xy-chart/utils/drawLabels.ts
@@ -11,13 +11,13 @@ export const drawTitle = (
     clipX: string | number = "39.5%";
   if (selection.node()?.getBoundingClientRect()) {
     logoX =
-      (selection.node()?.getBoundingClientRect().width as number) * 0.5 - 94;
+      (selection.node()?.getBoundingClientRect().width as number) * 0.5 - 84;
     clipX =
-      (selection.node()?.getBoundingClientRect().width as number) * 0.5 - 83;
+      (selection.node()?.getBoundingClientRect().width as number) * 0.5 - 73;
   }
   if (chartWidth) {
-    logoX = chartWidth * 0.5 - 94;
-    clipX = chartWidth * 0.5 - 83;
+    logoX = chartWidth * 0.5 - 84;
+    clipX = chartWidth * 0.5 - 73;
   }
 
   selection

--- a/src/components/Charts/StarXYChart.vue
+++ b/src/components/Charts/StarXYChart.vue
@@ -71,6 +71,7 @@ const drawStarChart = (data: XYChartData) => {
       },
       {
         xTickLabelType: props.chartMode === "Date" ? "Date" : "Number",
+        envType: "browser",
       }
     );
   }

--- a/src/components/StarChartViewer.vue
+++ b/src/components/StarChartViewer.vue
@@ -265,11 +265,13 @@ const handleGenerateImageBtnClick = async () => {
   }, 2000);
 
   try {
-    const { clientWidth, clientHeight } = svgElement;
+    // Get image's width and height from the container, because the svg's width is set to 100%
+    const { width: imgWidth, height: imgHeight } =
+      containerElRef.value.getBoundingClientRect();
     const canvas = document.createElement("canvas");
     const scale = Math.floor(window.devicePixelRatio * 2);
-    canvas.width = (clientWidth + 20) * scale;
-    canvas.height = (clientHeight + 30) * scale;
+    canvas.width = (imgWidth + 20) * scale;
+    canvas.height = (imgHeight + 30) * scale;
     const ctx = canvas.getContext("2d");
     if (!ctx) {
       toast.warn("Get canvas context failed.");
@@ -287,16 +289,16 @@ const handleGenerateImageBtnClick = async () => {
       chartImage,
       10 * scale,
       10 * scale,
-      clientWidth * scale,
-      clientHeight * scale
+      imgWidth * scale,
+      imgHeight * scale
     );
     // draw website link text
     ctx.font = `${16 * scale}px xkcd`;
     ctx.fillStyle = "#6b7280";
     ctx.fillText(
       "star-history.com",
-      (clientWidth - 130) * scale,
-      (clientHeight + 10) * scale
+      (imgWidth - 130) * scale,
+      (imgHeight + 10) * scale
     );
     // draw star image
     const starImage = new Image();
@@ -304,8 +306,8 @@ const handleGenerateImageBtnClick = async () => {
     await utils.waitImageLoaded(starImage);
     ctx.drawImage(
       starImage,
-      (clientWidth - 155) * scale,
-      (clientHeight - 5) * scale,
+      (imgWidth - 155) * scale,
+      (imgHeight - 5) * scale,
       20 * scale,
       20 * scale
     );


### PR DESCRIPTION
- Make chart more responsive in the browser, but the chart has a width of at least 600px. Also fit on mobile views.

| desktop | mobile |
|:--:|:--:|
| <img width="800" src="https://user-images.githubusercontent.com/56376387/174244749-d80ebdb2-2f3a-4e96-9706-66be0cc7f504.gif" /> | <img width="300" src="https://user-images.githubusercontent.com/56376387/174245437-ef8c69ad-6907-4f81-be17-9d932f13fac0.png" /> |

- Narrow down the spacing between logo and chart title.

<img width="700" src="https://user-images.githubusercontent.com/56376387/174244699-1d385ffc-64e7-41ca-a33a-e7afbe67c006.jpg" />